### PR TITLE
add `usesCleartextTraffic=true` to test http in local

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <application
         android:name=".UKMApplication"
         android:allowBackup="true"
+        android:usesCleartextTraffic="true"
         android:fullBackupContent="@xml/backup_descriptor"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
i found an error when try to test in local, and error said `Cleartext HTTP traffic not permitted`.

i add `usesCleartextTraffic=true` to solve this problem